### PR TITLE
A lot of bug fixes and mandatory additions.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,1 @@
+    <property name="project.structure.proportion" value="0.15" />

--- a/src/main/java/postest2/BaseController.java
+++ b/src/main/java/postest2/BaseController.java
@@ -1,0 +1,487 @@
+package postest2;
+
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.TextField;
+import javafx.scene.text.Text;
+import javafx.stage.FileChooser;
+import javafx.stage.WindowEvent;
+import jpos.BaseJposControl;
+import jpos.JposConst;
+import jpos.JposException;
+import jpos.events.*;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.swing.*;
+import java.awt.*;
+import java.io.*;
+import java.lang.reflect.Method;
+
+public abstract class BaseController implements Initializable, DataListener {
+
+    /* ************************************************************************
+     * ************************ Action Handler ********************************
+     * ************************************************************************
+     */
+
+    // Common
+    @FXML
+    public ComboBox<String> logicalName;
+    @FXML
+    public Button buttonOpen;
+    @FXML
+    @RequiredState(JposState.OPENED)
+    public Button buttonClaim;
+    @FXML
+    @RequiredState(JposState.CLAIMED)
+    public Button buttonRelease;
+    @FXML
+    @RequiredState(JposState.ENABLED)
+    public Button buttonStatistics;
+    @FXML
+    @RequiredState(JposState.OPENED)
+    public Button buttonClose;
+    @FXML
+    @RequiredState(JposState.ENABLED)
+    public Button buttonFirmware;
+    @FXML
+    @RequiredState(JposState.CLOSED)
+    public Button buttonOCE;
+    @FXML
+    @RequiredState(JposState.ENABLED)
+    public Button buttonInfo;
+    @FXML
+    public Text statusLabel;
+    @FXML
+    @RequiredState(JposState.ENABLED)
+    public CheckBox freezeEvents;
+    @FXML
+    @RequiredState(JposState.OPENED)
+    public CheckBox dataEventEnabled;
+
+    // WaitForDrawerClose
+    @FXML
+    public TextField waitForDrawerClose_beepTimeout;
+    @FXML
+    public TextField waitForDrawerClose_beepFrequency;
+    @FXML
+    public TextField waitForDrawerClose_beepDuration;
+    @FXML
+    public TextField waitForDrawerClose_beepDelay;
+
+    // DirectIO
+    @FXML
+    public TextField directIO_command;
+    @FXML
+    public TextField directIO_data;
+    @FXML
+    public TextField directIO_object;
+    @FXML
+    public RadioButton directIO_datatypeString;
+    @FXML
+    public RadioButton directIO_datatypeByteArray;
+
+    // Group for the radiobuttons
+    @FXML
+    public final ToggleGroup directIO_datatypeGroup = new ToggleGroup();
+
+    BaseJposControl service;
+
+    static String statistics = "";
+
+    @FXML
+    public void handleOpen(ActionEvent e) {
+        directIO_datatypeByteArray.setToggleGroup(directIO_datatypeGroup);
+        directIO_datatypeString.setToggleGroup(directIO_datatypeGroup);
+        directIO_datatypeByteArray.setSelected(true);
+
+
+        POSTest2.stage.setOnCloseRequest(new EventHandler<WindowEvent>() {
+            @Override
+            public void handle(WindowEvent arg0) {
+                try {
+                    if (getDeviceState(service) != JposState.CLOSED) {
+                        try {
+                            service.close();
+                        } catch (JposException e) {
+                            JOptionPane.showMessageDialog(null, e.getMessage());
+                            e.printStackTrace();
+                        }
+                    }
+                } catch (HeadlessException e) {
+                    e.printStackTrace();
+                } catch (JposException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+
+        try {
+            if (logicalName.getValue() != null && !logicalName.getValue().isEmpty()) {
+                service.open(logicalName.getValue());
+                RequiredStateChecker.invokeThis(this, service);
+                setStatusLabel();
+            } else {
+                JOptionPane.showMessageDialog(null, "Choose a device!", "Logical name is empty",
+                        JOptionPane.WARNING_MESSAGE);
+            }
+
+        } catch (JposException je) {
+            je.printStackTrace();
+            JOptionPane.showMessageDialog(null, "Failed to open \"" + logicalName.getSelectionModel().getSelectedItem()
+                    + "\"\nException: " + je.getMessage(), "Failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    @FXML
+    public void handleClaim(ActionEvent e) {
+        try {
+            service.claim(0);
+            RequiredStateChecker.invokeThis(this, service);
+        } catch (JposException je) {
+            je.printStackTrace();
+            JOptionPane.showMessageDialog(null, "Failed to claim \""
+                            + logicalName.getSelectionModel().getSelectedItem() + "\"\nException: " + je.getMessage(),
+                    "Failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    public void handleInfo(ActionEvent e) {
+
+    }
+
+    public void handleStatistics(ActionEvent e) {
+
+    }
+
+    // Method to parse the String XML and print the data for the
+    // handleStatistics function
+    public static void printStatistics(Node e, String tab) {
+        if (e.getNodeType() == Node.TEXT_NODE) {
+            statistics += tab + e.getNodeValue() + "\n";
+            return;
+        }
+
+        if (!(e.getNodeName().equals("Name") || e.getNodeName().equals("Value") || e.getNodeName().equals("UPOSStat")
+                || e.getNodeName().equals("Event") || e.getNodeName().equals("Equipment") || e.getNodeName().equals(
+                "Parameter")))
+            statistics += tab + e.getNodeName();
+
+        if (e.getNodeValue() != null) {
+            statistics += tab + " " + e.getNodeValue();
+        }
+
+        NodeList childs = e.getChildNodes();
+        for (int i = 0; i < childs.getLength(); i++) {
+            printStatistics(childs.item(i), " ");
+        }
+    }
+
+    @FXML
+    public void handleFirmware(ActionEvent e) {
+        try {
+            FirmwareUpdateDlg dlg = new FirmwareUpdateDlg(service);
+            dlg.setVisible(true);
+        } catch (Exception e2) {
+            e2.printStackTrace();
+            JOptionPane.showMessageDialog(null, "Exception: " + e2.getMessage(), "Failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    @FXML
+    public void handleFreezeEvents(ActionEvent e) {
+        try {
+            service.setFreezeEvents(freezeEvents.selectedProperty().getValue());
+        } catch (JposException e1) {
+            e1.printStackTrace();
+            JOptionPane.showMessageDialog(null, e1.getMessage());
+        }
+    }
+
+    @FXML
+    public void handleDataEventEnabled(ActionEvent e) {
+        Method setDataEventEnabled = getMethod(service, "setDataEventEnabled");
+        try {
+            if (setDataEventEnabled != null) {
+                setDataEventEnabled.invoke(service, dataEventEnabled.selectedProperty().getValue());
+            }
+        } catch (Exception e1) {
+            e1.printStackTrace();
+            JOptionPane.showMessageDialog(null, e1.getMessage());
+        }
+    }
+
+    Method getMethod(Object object, String name) {
+        try {
+            Method methods[] = Class.forName(object.getClass().getName()).getMethods();
+            for (Method method : methods) {
+                if (method.getName().equals(name)) {
+                    return method;
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @FXML
+    public void handleBrowseDirectIOData(ActionEvent e) {
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Choose DirectIOData");
+        File f = chooser.showOpenDialog(null);
+        if (f != null) {
+            directIO_data.setText(f.getAbsolutePath());
+        }
+    }
+
+    @FXML
+    public void handleBrowseDirectIOObject(ActionEvent e) {
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Choose DirectIOData");
+        File f = chooser.showOpenDialog(null);
+        if (f != null) {
+            directIO_object.setText(f.getAbsolutePath());
+        }
+    }
+
+    @FXML
+    public void handleDirectIO(ActionEvent e) {
+        if (directIO_command.getText().isEmpty() || directIO_data.getText().isEmpty()) {
+
+            JOptionPane.showMessageDialog(null, "One of the numeric parameters is not specified!");
+        } else {
+            try {
+                File fileData = new File(directIO_data.getText());
+                int[] dataArrInt = null;
+                if(fileData.exists()){
+                    // Reads content from File
+                    dataArrInt = readIntsFromFile(directIO_data.getText());
+                } else {
+                    String[] dataArrString = directIO_data.getText().split(",");
+                    dataArrInt = new int[dataArrString.length];
+                    for (int i = 0; i < dataArrString.length; i++) {
+                        dataArrInt[i] = Integer.parseInt(dataArrString[i]);
+                    }
+                }
+                Object object = null;
+
+                File fileObject = new File(directIO_object.getText());
+                if(fileObject.exists()){
+                    if(directIO_datatypeByteArray.isSelected()){
+                        object = readBytesFromFile(directIO_object.getText());
+                    } else if(directIO_datatypeString.isSelected()){
+                        object = convertBytesToString(readBytesFromFile(directIO_object.getText()));
+                    }
+                } else {
+                    if(directIO_datatypeByteArray.isSelected()){
+                        String[] objArrString = directIO_object.getText().split(",");
+                        byte[] objectArr = new byte[objArrString.length];
+                        for (int i = 0; i < objArrString.length; i++) {
+                            objectArr[i] = Byte.parseByte(objArrString[i]);
+                        }
+                        object = objectArr;
+                    } else if(directIO_datatypeString.isSelected()){
+                        object = directIO_object.getText();
+                    }
+                }
+
+                // Execute DirectIO
+                service.directIO(Integer.parseInt(directIO_command.getText()), dataArrInt, object);
+
+            } catch (JposException e1) {
+                JOptionPane.showMessageDialog(null, e1.getMessage());
+                e1.printStackTrace();
+            } catch (NumberFormatException e1) {
+                JOptionPane.showMessageDialog(null, e1.getMessage());
+                e1.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Set StatusLabel corresponding to the Device Status
+     */
+    void setStatusLabel() {
+        if (service.getState() == JposConst.JPOS_S_IDLE) {
+            statusLabel.setText("JPOS_S_IDLE");
+        }
+
+        if (service.getState() == JposConst.JPOS_S_CLOSED) {
+            statusLabel.setText("JPOS_S_CLOSED");
+        }
+
+        if (service.getState() == JposConst.JPOS_S_BUSY) {
+            statusLabel.setText("JPOS_S_BUSY");
+        }
+
+        if (service.getState() == JposConst.JPOS_S_ERROR) {
+            statusLabel.setText("JPOS_S_ERROR");
+        }
+    }
+
+    protected void setUpLogicalNameComboBox(String devCategory) {
+        if (!LogicalNameGetter.getLogicalNamesByCategory(devCategory).isEmpty()) {
+            logicalName.setItems(LogicalNameGetter.getLogicalNamesByCategory(devCategory));
+        }
+    }
+
+    /**
+     * Read the given binary file, and return its contents as a byte array.
+     *
+     */
+    protected static byte[] readBytesFromFile(String aInputFileName) {
+        File file = new File(aInputFileName);
+        byte[] result = new byte[(int) file.length()];
+        try {
+            InputStream input = null;
+            try {
+                int totalBytesRead = 0;
+                input = new BufferedInputStream(new FileInputStream(file));
+                while (totalBytesRead < result.length) {
+                    int bytesRemaining = result.length - totalBytesRead;
+                    // input.read() returns -1, 0, or more :
+                    int bytesRead = input.read(result, totalBytesRead, bytesRemaining);
+                    if (bytesRead > 0) {
+                        totalBytesRead = totalBytesRead + bytesRead;
+                    }
+                }
+            } finally {
+                input.close();
+            }
+        } catch (FileNotFoundException ex) {
+
+            JOptionPane.showMessageDialog(null, ex.getMessage());
+            ex.printStackTrace();
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(null, ex.getMessage());
+            ex.printStackTrace();
+
+        }
+        return result;
+    }
+
+    /**
+     * Read the given binary file, and return its contents as a byte array.
+     *
+     */
+    protected static int[] readIntsFromFile(String aInputFileName) {
+        File file = new File(aInputFileName);
+        int[] result = new int[(int) file.length()];
+        try {
+            InputStream input = null;
+            try {
+                input = new BufferedInputStream(new FileInputStream(file));
+                int readInt;
+                int num= 0;
+                while ((readInt = input.read()) != -1) {
+                    result[num] = readInt;
+                    num ++;
+                }
+            } finally {
+                input.close();
+            }
+        } catch (FileNotFoundException ex) {
+            JOptionPane.showMessageDialog(null, ex.getMessage());
+            ex.printStackTrace();
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(null, ex.getMessage());
+            ex.printStackTrace();
+
+        }
+        return result;
+    }
+
+    /**
+     * Converty a byte[] to a String
+     *
+     */
+    protected static String convertBytesToString(byte[] bytesFromFile) {
+        String ret = "";
+
+        for (int i = 0; i < bytesFromFile.length; i++) {
+            if (i != 0) {
+                ret += ",";
+            }
+            ret += (int) bytesFromFile[i];
+        }
+
+        return ret;
+    }
+
+    /**
+     * Write a byte array to the given file. Writing binary data is
+     * significantly simpler than reading it.
+     */
+    protected static void writeBytesToFile(byte[] aInput, String aOutputFileName) {
+        try {
+            OutputStream output = null;
+            try {
+                output = new BufferedOutputStream(new FileOutputStream(aOutputFileName));
+                output.write(aInput);
+            } finally {
+                output.close();
+            }
+        } catch (FileNotFoundException ex) {
+            JOptionPane.showMessageDialog(null, ex.getMessage());
+            ex.printStackTrace();
+        } catch (IOException ex) {
+            JOptionPane.showMessageDialog(null, ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+
+    /**
+     * Sets the tooltips for the common buttons (Open, Claim, Release, Close, ..)
+     */
+    protected void setUpTooltips() {
+        buttonClaim.setTooltip(new Tooltip("Claims the Device"));
+        buttonClose.setTooltip(new Tooltip("Closes the connection to the Device"));
+        buttonFirmware.setTooltip(new Tooltip("Update or view the Firmware Version of the Device"));
+        buttonInfo.setTooltip(new Tooltip("Shows Information about the Device"));
+        buttonOCE.setTooltip(new Tooltip("Open, Claims and Enables the Device"));
+        buttonOpen.setTooltip(new Tooltip("Opens the Device"));
+        buttonRelease.setTooltip(new Tooltip("Releases the Device"));
+        buttonStatistics.setTooltip(new Tooltip("View, reset or update Device Statistics"));
+    }
+
+    /**
+     * Gets the current DeviceState
+     *
+     * @param service
+     * @return
+     * @throws JposException
+     */
+    protected static JposState getDeviceState(BaseJposControl service) throws JposException {
+        JposState deviceState = null;
+        try {
+            if (!service.getClaimed()) {
+                deviceState = JposState.OPENED;
+            }
+            if (service.getClaimed()) {
+                deviceState = JposState.CLAIMED;
+            }
+
+            if (service.getDeviceEnabled()) {
+                deviceState = JposState.ENABLED;
+            }
+        } catch (JposException e) {
+            if (e.getErrorCode() == JposConst.JPOS_E_CLOSED) {
+                deviceState = JposState.CLOSED;
+            }
+        }
+        return deviceState;
+
+    }
+
+    @Override
+    public void dataOccurred(DataEvent dataEvent) {
+        dataEventEnabled.setSelected(false);
+    }
+
+}

--- a/src/main/java/postest2/CATController.java
+++ b/src/main/java/postest2/CATController.java
@@ -1,11 +1,12 @@
 package postest2;
 
-import java.awt.Dimension;
+import java.awt.*;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
+import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -14,9 +15,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextField;
 
-import javax.swing.JOptionPane;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
+import javax.swing.*;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -24,12 +23,16 @@ import javax.xml.parsers.ParserConfigurationException;
 import jpos.CAT;
 import jpos.JposException;
 
+import jpos.events.ErrorEvent;
+import jpos.events.ErrorListener;
+import jpos.events.OutputCompleteEvent;
+import jpos.events.OutputCompleteListener;
 import org.apache.xerces.parsers.DOMParser;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class CATController extends CommonController implements Initializable {
+public class CATController extends CommonController implements Initializable, ErrorListener, OutputCompleteListener {
 
 	@FXML
 	@RequiredState(JposState.ENABLED)
@@ -76,6 +79,8 @@ public class CATController extends CommonController implements Initializable {
 	public void initialize(URL arg0, ResourceBundle arg1) {
 		setUpTooltips();
 		service = new CAT();
+		((CAT)service).addErrorListener(this);
+		((CAT)service).addOutputCompleteListener(this);
 		setUpLogicalNameComboBox("CAT");
 		RequiredStateChecker.invokeThis(this, service);
 	}
@@ -96,6 +101,14 @@ public class CATController extends CommonController implements Initializable {
 			}
 		} catch (JposException e1) {
 			e1.printStackTrace();
+		}
+	}
+
+	@Override
+	public void handleClose(ActionEvent e) {
+		super.handleClose(e);
+		if (asyncMode.isSelected()) {
+			asyncMode.setSelected(false);
 		}
 	}
 
@@ -234,6 +247,12 @@ public class CATController extends CommonController implements Initializable {
 				((CAT) service).accessDailyLog(Integer.parseInt(accessDailyLog_sequenceNumber.getText()),
 						CATConstantMapper.getConstantNumberFromString(accessDailyLog_type.getSelectionModel()
 								.getSelectedItem()), Integer.parseInt(accessDailyLog_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
@@ -256,6 +275,12 @@ public class CATController extends CommonController implements Initializable {
 				((CAT) service).authorizeCompletion(Integer.parseInt(authorize_sequenceNumber.getText()),
 						Long.parseLong(authorize_amount.getText()), Long.parseLong(authorize_taxOthers.getText()),
 						Integer.parseInt(authorize_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -277,6 +302,12 @@ public class CATController extends CommonController implements Initializable {
 				((CAT) service).authorizePreSales(Integer.parseInt(authorize_sequenceNumber.getText()),
 						Long.parseLong(authorize_amount.getText()), Long.parseLong(authorize_taxOthers.getText()),
 						Integer.parseInt(authorize_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -300,6 +331,12 @@ public class CATController extends CommonController implements Initializable {
 						Long.parseLong(authorize_amount.getText()), Long.parseLong(authorize_taxOthers.getText()),
 
 						Integer.parseInt(authorize_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -324,6 +361,12 @@ public class CATController extends CommonController implements Initializable {
 						Long.parseLong(authorize_amount.getText()), Long.parseLong(authorize_taxOthers.getText()),
 
 						Integer.parseInt(authorize_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -348,6 +391,12 @@ public class CATController extends CommonController implements Initializable {
 						Long.parseLong(authorize_amount.getText()), Long.parseLong(authorize_taxOthers.getText()),
 
 						Integer.parseInt(authorize_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -370,6 +419,12 @@ public class CATController extends CommonController implements Initializable {
 				((CAT) service).authorizeVoidPreSales(Integer.parseInt(authorize_sequenceNumber.getText()),
 						Long.parseLong(authorize_amount.getText()), Long.parseLong(authorize_taxOthers.getText()),
 						Integer.parseInt(authorize_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -389,6 +444,12 @@ public class CATController extends CommonController implements Initializable {
 			try {
 				((CAT) service).cashDeposit(Integer.parseInt(cashDeposit_sequenceNumber.getText()),
 						Long.parseLong(cashDeposit_amount.getText()), Integer.parseInt(cashDeposit_timeout.getText()));
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -408,6 +469,12 @@ public class CATController extends CommonController implements Initializable {
 				((CAT) service).checkCard(Integer.parseInt(checkCard_sequenceNumber.getText()),
 						Integer.parseInt(checkCard_timeout.getText()));
 
+				if (asyncMode.isSelected()) {
+					setStatusLabel();
+				}
+				else {
+					updateWritableProperties();
+				}
 			} catch (NumberFormatException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();
@@ -423,6 +490,12 @@ public class CATController extends CommonController implements Initializable {
 		try {
 			((CAT) service).lockTerminal();
 
+			if (asyncMode.isSelected()) {
+				setStatusLabel();
+			}
+			else {
+				updateWritableProperties();
+			}
 		} catch (JposException e1) {
 			JOptionPane.showMessageDialog(null, e1.getMessage());
 			e1.printStackTrace();
@@ -433,6 +506,12 @@ public class CATController extends CommonController implements Initializable {
 	public void handleUnlockTerminal(ActionEvent e) {
 		try {
 			((CAT) service).unlockTerminal();
+			if (asyncMode.isSelected()) {
+				setStatusLabel();
+			}
+			else {
+				updateWritableProperties();
+			}
 		} catch (JposException e1) {
 			JOptionPane.showMessageDialog(null, e1.getMessage());
 			e1.printStackTrace();
@@ -474,6 +553,48 @@ public class CATController extends CommonController implements Initializable {
 		setUpAccessDailyLogType();
 	}
 
-	
 
+	@Override
+	public void errorOccurred(ErrorEvent e) {
+		JOptionPane.showMessageDialog(null, "Asynchronous operation failed: " + e.getErrorCode() + "/" + e.getErrorCodeExtended());
+		try {
+			((CAT)service).clearOutput();
+		} catch (JposException ex) {
+			ex.printStackTrace();
+		}
+		setStatusLabel();
+	}
+
+	@Override
+	public void outputCompleteOccurred(OutputCompleteEvent outputCompleteEvent) {
+		Platform.runLater(new Runnable() {
+			public void run() {
+				updateWritableProperties();
+			}
+		});
+		setStatusLabel();
+	}
+
+	private void updateWritableProperties() {
+		try {
+			additionalSecurityInformation.setText(((CAT)service).getAdditionalSecurityInformation());
+			int medium = ((CAT)service).getPaymentMedia();
+			String mediumText = paymentMedia.getValue();
+			if (medium == CATConstantMapper.CAT_MEDIA_UNSPECIFIED.getContantNumber())
+				mediumText = CATConstantMapper.CAT_MEDIA_UNSPECIFIED.getConstant();
+			else if (medium == CATConstantMapper.CAT_MEDIA_NONDEFINE.getContantNumber())
+				mediumText = CATConstantMapper.CAT_MEDIA_NONDEFINE.getConstant();
+			else if (medium == CATConstantMapper.CAT_MEDIA_CREDIT.getContantNumber())
+				mediumText = CATConstantMapper.CAT_MEDIA_CREDIT.getConstant();
+			else if (medium == CATConstantMapper.CAT_MEDIA_DEBIT.getContantNumber())
+				mediumText = CATConstantMapper.CAT_MEDIA_DEBIT.getConstant();
+			else if (medium == CATConstantMapper.CAT_MEDIA_ELECTRONIC_MONEY.getContantNumber())
+				mediumText = CATConstantMapper.CAT_MEDIA_ELECTRONIC_MONEY.getConstant();
+
+			if (medium != CATConstantMapper.getConstantNumberFromString(paymentMedia.getValue()))
+				paymentMedia.setValue(mediumText);
+		} catch (JposException e) {
+			e.printStackTrace();
+		}
+	}
 }

--- a/src/main/java/postest2/CashDrawerController.java
+++ b/src/main/java/postest2/CashDrawerController.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class CashDrawerController extends CommonController implements Initializable, StatusUpdateListener {
+public class CashDrawerController extends SharableController implements Initializable, StatusUpdateListener {
 	
 	@FXML
 	@RequiredState(JposState.ENABLED)
@@ -65,11 +65,23 @@ public class CashDrawerController extends CommonController implements Initializa
 		try {
 			if (deviceEnabled.isSelected()) {
 				((CashDrawer) service).setDeviceEnabled(true);
+				if (waitForDrawerClose_beepTimeout.getText().equals("")) {
+					waitForDrawerClose_beepTimeout.setText("100");
+				}
+				if (waitForDrawerClose_beepFrequency.getText().equals("")) {
+					waitForDrawerClose_beepFrequency.setText("500");
+				}
+				if (waitForDrawerClose_beepDuration.getText().equals("")) {
+					waitForDrawerClose_beepDuration.setText("100");
+				}
+				if (waitForDrawerClose_beepDelay.getText().equals("")) {
+					waitForDrawerClose_beepDelay.setText("200");
+				}
 			} else {
 				((CashDrawer) service).setDeviceEnabled(false);
 			}
 			RequiredStateChecker.invokeThis(this, service);
-		} catch (JposException je) {   
+		} catch (JposException je) {
 			JOptionPane.showMessageDialog(null, je.getMessage());
 			je.printStackTrace();
 		}
@@ -80,7 +92,7 @@ public class CashDrawerController extends CommonController implements Initializa
 	public void handleOCE(ActionEvent e) {
 		super.handleOCE(e);
 		try {
-			if(getDeviceState(service) == JposState.CLAIMED){
+			if(getDeviceState(service) == JposState.OPENED){
 				deviceEnabled.setSelected(true);
 				handleDeviceEnable(e);
 			}
@@ -93,6 +105,7 @@ public class CashDrawerController extends CommonController implements Initializa
 	public void handleOpenCash(ActionEvent e) {
 		try {
 			((CashDrawer) service).openDrawer();
+			textAreaActionLog.appendText("Cash drawer opened.\n");
 		} catch (JposException je) {
 			je.printStackTrace();
 			JOptionPane.showMessageDialog(null, "Exception in openDrawer: " + je.getMessage(), "Exception",
@@ -109,19 +122,26 @@ public class CashDrawerController extends CommonController implements Initializa
 				textAreaActionLog.appendText("Cash drawer is closed.\n");
 			}
 		} catch (JposException je) {
-			JOptionPane.showMessageDialog(null, je.getMessage());
 			je.printStackTrace();
+			JOptionPane.showMessageDialog(null, je.getMessage());
 		}
 	}
 
 	@FXML
 	public void handleWaitForDrawer(ActionEvent e) {
 		try {
-			((CashDrawer) service).waitForDrawerClose(100, 500, 100, 200);
+			int beepTimeout = Integer.parseInt(waitForDrawerClose_beepTimeout.getText());
+			int beepFrequency = Integer.parseInt(waitForDrawerClose_beepFrequency.getText());
+			int beepDuration = Integer.parseInt(waitForDrawerClose_beepDuration.getText());
+			int beepDelay = Integer.parseInt(waitForDrawerClose_beepDelay.getText());
+			((CashDrawer) service).waitForDrawerClose(beepTimeout, beepFrequency, beepDuration, beepDelay);
 			textAreaActionLog.appendText("Cash drawer is closed.\n");
 		} catch (JposException je) {
-			JOptionPane.showMessageDialog(null, je.getMessage());
 			je.printStackTrace();
+			JOptionPane.showMessageDialog(null, je.getMessage());
+		} catch (NumberFormatException ne) {
+			ne.printStackTrace();
+			JOptionPane.showMessageDialog(null, ne.getMessage());
 		}
 	}
 
@@ -204,5 +224,4 @@ public class CashDrawerController extends CommonController implements Initializa
 			break;
 		}
 	}
-	
 }

--- a/src/main/java/postest2/CoinDispenserConstantMapper.java
+++ b/src/main/java/postest2/CoinDispenserConstantMapper.java
@@ -20,4 +20,34 @@ public class CoinDispenserConstantMapper implements IMapWrapper {
 		return this;
 	}
 
+	/**
+	 * Get Constant Number from String - Needed because ComboBoxes just hold the
+	 * String and not the Object
+	 *
+	 * @param constant
+	 * @return
+	 */
+	public static int getConstantNumberFromString(String constant){
+		if(constant.equals(CoinDispenserConstantMapper.COIN_STATUS_OK.getConstant())) {
+			return CoinDispenserConstantMapper.COIN_STATUS_OK.getContantNumber();
+		}
+
+		if(constant.equals(CoinDispenserConstantMapper.COIN_STATUS_NEAREMPTY.getConstant())) {
+			return CoinDispenserConstantMapper.COIN_STATUS_NEAREMPTY.getContantNumber();
+		}
+
+		if(constant.equals(CoinDispenserConstantMapper.COIN_STATUS_EMPTY.getConstant())) {
+			return CoinDispenserConstantMapper.COIN_STATUS_EMPTY.getContantNumber();
+		}
+
+		if(constant.equals(CoinDispenserConstantMapper.COIN_STATUS_JAM.getConstant())) {
+			return CoinDispenserConstantMapper.COIN_STATUS_JAM.getContantNumber();
+		}
+
+		if(constant.equals(CoinDispenserConstantMapper.COIN_STATUS_OK.getConstant())) {
+			return CoinDispenserConstantMapper.COIN_STATUS_OK.getContantNumber();
+		}
+
+		return Integer.parseInt(constant);
+	}
 }

--- a/src/main/java/postest2/CoinDispenserController.java
+++ b/src/main/java/postest2/CoinDispenserController.java
@@ -162,9 +162,9 @@ public class CoinDispenserController extends CommonController implements Initial
 
 	@FXML
 	public void handleDispenseCash(ActionEvent e) {
-		if (!adjustCashCounts.getText().isEmpty()) {
+		if (!dispenseCash_cashCounts.getText().isEmpty()) {
 			try {
-				((CoinDispenser) service).adjustCashCounts(adjustCashCounts.getText());
+				((CoinDispenser) service).dispenseChange(Integer.parseInt(dispenseCash_cashCounts.getText()));
 			} catch (JposException e1) {
 				JOptionPane.showMessageDialog(null, e1.getMessage());
 				e1.printStackTrace();

--- a/src/main/java/postest2/CommonController.java
+++ b/src/main/java/postest2/CommonController.java
@@ -1,164 +1,31 @@
 package postest2;
 
-import java.awt.HeadlessException;
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.RadioButton;
-import javafx.scene.control.TextField;
-import javafx.scene.control.ToggleGroup;
-import javafx.scene.control.Tooltip;
-import javafx.scene.text.Text;
-import javafx.stage.FileChooser;
-import javafx.stage.WindowEvent;
 
 import javax.swing.JOptionPane;
 
-import jpos.BaseJposControl;
-import jpos.JposConst;
 import jpos.JposException;
 
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-public abstract class CommonController implements Initializable {
+public abstract class CommonController extends BaseController implements Initializable {
 
 	/* ************************************************************************
-	 * ************************ Action Handler ********************************
+	 * *************** Action Handler For Exclusive Use Devices ***************
 	 * ************************************************************************
 	 */
 
 	// Common
 	@FXML
-	public ComboBox<String> logicalName;
-	@FXML
 	@RequiredState(JposState.CLAIMED)
 	public CheckBox deviceEnabled;
-	@FXML
-	public Button buttonOpen;
-	@FXML
-	@RequiredState(JposState.OPENED)
-	public Button buttonClaim;
-	@FXML
-	@RequiredState(JposState.CLAIMED)
-	public Button buttonRelease;
-	@FXML
-	@RequiredState(JposState.ENABLED)
-	public Button buttonStatistics;
-	@FXML
-	@RequiredState(JposState.OPENED)
-	public Button buttonClose;
-	@FXML
-	@RequiredState(JposState.ENABLED)
-	public Button buttonFirmware;
-	@FXML
-	@RequiredState(JposState.CLOSED)
-	public Button buttonOCE;
-	@FXML
-	@RequiredState(JposState.ENABLED)
-	public Button buttonInfo;
-	@FXML
-	public Text statusLabel;
-	@FXML
-	@RequiredState(JposState.ENABLED)
-	public CheckBox freezeEvents;
-
-	// DirectIO
-	@FXML
-	public TextField directIO_command;
-	@FXML
-	public TextField directIO_data;
-	@FXML
-	public TextField directIO_object;
-	@FXML
-	public RadioButton directIO_datatypeString;
-	@FXML
-	public RadioButton directIO_datatypeByteArray;
-	
-	// Group for the radiobuttons
-	@FXML
-	public final ToggleGroup directIO_datatypeGroup = new ToggleGroup();
-
-	BaseJposControl service;
-
-	static String statistics = "";
-
-	@FXML
-	public void handleOpen(ActionEvent e) {
-		directIO_datatypeByteArray.setToggleGroup(directIO_datatypeGroup);
-		directIO_datatypeString.setToggleGroup(directIO_datatypeGroup);
-		directIO_datatypeByteArray.setSelected(true);
-		
-		
-		POSTest2.stage.setOnCloseRequest(new EventHandler<WindowEvent>() {
-			@Override
-			public void handle(WindowEvent arg0) {
-				try {
-					if (getDeviceState(service) != JposState.CLOSED) {
-						try {
-							service.close();
-						} catch (JposException e) {
-							JOptionPane.showMessageDialog(null, e.getMessage());
-							e.printStackTrace();
-						}
-					}
-				} catch (HeadlessException e) {
-					e.printStackTrace();
-				} catch (JposException e) {
-					e.printStackTrace();
-				}
-			}
-		});
-
-		try {
-			if (logicalName.getValue() != null && !logicalName.getValue().isEmpty()) {
-				service.open(logicalName.getValue());
-				RequiredStateChecker.invokeThis(this, service);
-				setStatusLabel();
-			} else {
-				JOptionPane.showMessageDialog(null, "Choose a device!", "Logical name is empty",
-						JOptionPane.WARNING_MESSAGE);
-			}
-
-		} catch (JposException je) {
-			je.printStackTrace();
-			JOptionPane.showMessageDialog(null, "Failed to open \"" + logicalName.getSelectionModel().getSelectedItem()
-					+ "\"\nException: " + je.getMessage(), "Failed", JOptionPane.ERROR_MESSAGE);
-		}
-	}
-
-	@FXML
-	public void handleClaim(ActionEvent e) {
-		try {
-			service.claim(0);
-			RequiredStateChecker.invokeThis(this, service);
-		} catch (JposException je) {
-			je.printStackTrace();
-			JOptionPane.showMessageDialog(null, "Failed to claim \""
-					+ logicalName.getSelectionModel().getSelectedItem() + "\"\nException: " + je.getMessage(),
-					"Failed", JOptionPane.ERROR_MESSAGE);
-		}
-	}
 
 	@FXML
 	public void handleRelease(ActionEvent e) {
 		try {
 			service.release();
-			if (deviceEnabled.isSelected()) {
+			if (deviceEnabled.isSelected() && service.getDeviceEnabled() == false) {
 				deviceEnabled.setSelected(false);
 			}
 
@@ -179,6 +46,10 @@ public abstract class CommonController implements Initializable {
 				deviceEnabled.setSelected(false);
 			}
 
+			if (dataEventEnabled != null && !dataEventEnabled.isDisable()) {
+				dataEventEnabled.setSelected(false);
+			}
+
 			RequiredStateChecker.invokeThis(this, service);
 			setStatusLabel();
 		} catch (JposException je) {
@@ -194,314 +65,12 @@ public abstract class CommonController implements Initializable {
 		try {
 			if(getDeviceState(service) == JposState.CLOSED){
 				handleOpen(e);
-			} 
+			}
 			if(getDeviceState(service) == JposState.OPENED){
 				handleClaim(e);
 			}
 		} catch (JposException e1) {
 			e1.printStackTrace();
 		}
-	}
-
-	public void handleInfo(ActionEvent e) {
-		
-	}
-
-	public void handleStatistics(ActionEvent e) {
-
-	}
-
-	// Method to parse the String XML and print the data for the
-	// handleStatistics function
-	public static void printStatistics(Node e, String tab) {
-		if (e.getNodeType() == Node.TEXT_NODE) {
-			statistics += tab + e.getNodeValue() + "\n";
-			return;
-		}
-
-		if (!(e.getNodeName().equals("Name") || e.getNodeName().equals("Value") || e.getNodeName().equals("UPOSStat")
-				|| e.getNodeName().equals("Event") || e.getNodeName().equals("Equipment") || e.getNodeName().equals(
-				"Parameter")))
-			statistics += tab + e.getNodeName();
-
-		if (e.getNodeValue() != null) {
-			statistics += tab + " " + e.getNodeValue();
-		}
-
-		NodeList childs = e.getChildNodes();
-		for (int i = 0; i < childs.getLength(); i++) {
-			printStatistics(childs.item(i), " ");
-		}
-	}
-
-	@FXML
-	public void handleFirmware(ActionEvent e) {
-		try {
-			FirmwareUpdateDlg dlg = new FirmwareUpdateDlg(service);
-			dlg.setVisible(true);
-		} catch (Exception e2) {
-			e2.printStackTrace();
-			JOptionPane.showMessageDialog(null, "Exception: " + e2.getMessage(), "Failed", JOptionPane.ERROR_MESSAGE);
-		}
-	}
-
-	@FXML
-	public void handleFreezeEvents(ActionEvent e) {
-		try {
-			service.setFreezeEvents(freezeEvents.selectedProperty().getValue());
-		} catch (JposException e1) {
-			e1.printStackTrace();
-			JOptionPane.showMessageDialog(null, e1.getMessage());
-		}
-	}
-
-	@FXML
-	public void handleBrowseDirectIOData(ActionEvent e) {
-		FileChooser chooser = new FileChooser();
-		chooser.setTitle("Choose DirectIOData");
-		File f = chooser.showOpenDialog(null);
-		if (f != null) {
-			directIO_data.setText(f.getAbsolutePath());
-		}
-	}
-	
-	@FXML
-	public void handleBrowseDirectIOObject(ActionEvent e) {
-		FileChooser chooser = new FileChooser();
-		chooser.setTitle("Choose DirectIOData");
-		File f = chooser.showOpenDialog(null);
-		if (f != null) {
-			directIO_object.setText(f.getAbsolutePath());
-		}
-	}
-
-	@FXML
-	public void handleDirectIO(ActionEvent e) {
-		if (directIO_command.getText().isEmpty() || directIO_data.getText().isEmpty()
-				|| directIO_object.getText().isEmpty()) {
-
-			JOptionPane.showMessageDialog(null, "One of the Parameter is not specified!");
-		} else {
-			try {
-				File fileData = new File(directIO_data.getText());
-				int[] dataArrInt = null;
-				if(fileData.exists()){
-					// Reads content from File
-					dataArrInt = readIntsFromFile(directIO_data.getText());
-				} else {
-					String[] dataArrString = directIO_data.getText().split(",");
-					dataArrInt = new int[dataArrString.length];
-					for (int i = 0; i < dataArrString.length; i++) {
-						dataArrInt[i] = Integer.parseInt(dataArrString[i]);
-					}
-				}
-				Object object = null;
-				
-				File fileObject = new File(directIO_object.getText());
-				if(fileObject.exists()){
-					if(directIO_datatypeByteArray.isSelected()){
-						object = readBytesFromFile(directIO_object.getText());
-					} else if(directIO_datatypeString.isSelected()){
-						object = convertBytesToString(readBytesFromFile(directIO_object.getText()));
-					}
-				} else {
-					if(directIO_datatypeByteArray.isSelected()){
-						String[] objArrString = directIO_object.getText().split(",");
-						byte[] objectArr = new byte[objArrString.length];
-						for (int i = 0; i < objArrString.length; i++) {
-							objectArr[i] = Byte.parseByte(objArrString[i]);
-						}
-						object = objectArr;
-					} else if(directIO_datatypeString.isSelected()){
-						object = directIO_object.getText();
-					}
-				}
-				
-				// Execute DirectIO
-				service.directIO(Integer.parseInt(directIO_command.getText()), dataArrInt, object);
-
-			} catch (JposException e1) {
-				JOptionPane.showMessageDialog(null, e1.getMessage());
-				e1.printStackTrace();
-			} catch (NumberFormatException e1) {
-				JOptionPane.showMessageDialog(null, e1.getMessage());
-				e1.printStackTrace();
-			}
-		}
-	}
-
-	/**
-	 * Set StatusLabel corresponding to the Device Status
-	 */
-	private void setStatusLabel() {
-		if (service.getState() == JposConst.JPOS_S_IDLE) {
-			statusLabel.setText("JPOS_S_IDLE");
-		}
-
-		if (service.getState() == JposConst.JPOS_S_CLOSED) {
-			statusLabel.setText("JPOS_S_CLOSED");
-		}
-
-		if (service.getState() == JposConst.JPOS_S_BUSY) {
-			statusLabel.setText("JPOS_S_BUSY");
-		}
-
-		if (service.getState() == JposConst.JPOS_S_ERROR) {
-			statusLabel.setText("JPOS_S_ERROR");
-		}
-	}
-
-	protected void setUpLogicalNameComboBox(String devCategory) {
-		if (!LogicalNameGetter.getLogicalNamesByCategory(devCategory).isEmpty()) {
-			logicalName.setItems(LogicalNameGetter.getLogicalNamesByCategory(devCategory));
-		}
-	}
-
-	/**
-	 * Read the given binary file, and return its contents as a byte array.
-	 * 
-	 */
-	protected static byte[] readBytesFromFile(String aInputFileName) {
-		File file = new File(aInputFileName);
-		byte[] result = new byte[(int) file.length()];
-		try {
-			InputStream input = null;
-			try {
-				int totalBytesRead = 0;
-				input = new BufferedInputStream(new FileInputStream(file));
-				while (totalBytesRead < result.length) {
-					int bytesRemaining = result.length - totalBytesRead;
-					// input.read() returns -1, 0, or more :
-					int bytesRead = input.read(result, totalBytesRead, bytesRemaining);
-					if (bytesRead > 0) {
-						totalBytesRead = totalBytesRead + bytesRead;
-					}
-				}
-			} finally {
-				input.close();
-			}
-		} catch (FileNotFoundException ex) {
-
-			JOptionPane.showMessageDialog(null, ex.getMessage());
-			ex.printStackTrace();
-		} catch (IOException ex) {
-			JOptionPane.showMessageDialog(null, ex.getMessage());
-			ex.printStackTrace();
-
-		}
-		return result;
-	}
-	
-	/**
-	 * Read the given binary file, and return its contents as a byte array.
-	 * 
-	 */
-	protected static int[] readIntsFromFile(String aInputFileName) {
-		File file = new File(aInputFileName);
-		int[] result = new int[(int) file.length()];
-		try {
-			InputStream input = null;
-			try {
-				input = new BufferedInputStream(new FileInputStream(file));
-				int readInt;
-				int num= 0;
-				while ((readInt = input.read()) != -1) {
-					result[num] = readInt;
-					num ++;
-				}
-			} finally {
-				input.close();
-			}
-		} catch (FileNotFoundException ex) {
-			JOptionPane.showMessageDialog(null, ex.getMessage());
-			ex.printStackTrace();
-		} catch (IOException ex) {
-			JOptionPane.showMessageDialog(null, ex.getMessage());
-			ex.printStackTrace();
-
-		}
-		return result;
-	}
-
-	/**
-	 * Converty a byte[] to a String
-	 * 
-	 */
-	protected static String convertBytesToString(byte[] bytesFromFile) {
-		String ret = "";
-
-		for (int i = 0; i < bytesFromFile.length; i++) {
-			if (i != 0) {
-				ret += ",";
-			}
-			ret += (int) bytesFromFile[i];
-		}
-
-		return ret;
-	}
-
-	/**
-	 * Write a byte array to the given file. Writing binary data is
-	 * significantly simpler than reading it.
-	 */
-	protected static void writeBytesToFile(byte[] aInput, String aOutputFileName) {
-		try {
-			OutputStream output = null;
-			try {
-				output = new BufferedOutputStream(new FileOutputStream(aOutputFileName));
-				output.write(aInput);
-			} finally {
-				output.close();
-			}
-		} catch (FileNotFoundException ex) {
-			JOptionPane.showMessageDialog(null, ex.getMessage());
-			ex.printStackTrace();
-		} catch (IOException ex) {
-			JOptionPane.showMessageDialog(null, ex.getMessage());
-			ex.printStackTrace();
-		}
-	}
-
-	/**
-	 * Sets the tooltips for the common buttons (Open, Claim, Release, Close, ..)
-	 */
-	protected void setUpTooltips() {
-		buttonClaim.setTooltip(new Tooltip("Claims the Device"));
-		buttonClose.setTooltip(new Tooltip("Closes the connection to the Device"));
-		buttonFirmware.setTooltip(new Tooltip("Update or view the Firmware Version of the Device"));
-		buttonInfo.setTooltip(new Tooltip("Shows Information about the Device"));
-		buttonOCE.setTooltip(new Tooltip("Open, Claims and Enables the Device"));
-		buttonOpen.setTooltip(new Tooltip("Opens the Device"));
-		buttonRelease.setTooltip(new Tooltip("Releases the Device"));
-		buttonStatistics.setTooltip(new Tooltip("View, reset or update Device Statistics"));
-	}
-
-	/**
-	 * Gets the current DeviceState
-	 * 
-	 * @param service
-	 * @return
-	 * @throws JposException
-	 */
-	protected static JposState getDeviceState(BaseJposControl service) throws JposException {
-		JposState deviceState = null;
-		try {
-			if (!service.getClaimed()) {
-				deviceState = JposState.OPENED;
-			}
-			if (service.getClaimed()) {
-				deviceState = JposState.CLAIMED;
-			}
-
-			if (service.getDeviceEnabled()) {
-				deviceState = JposState.ENABLED;
-			}
-		} catch (JposException e) {
-			if (e.getErrorCode() == JposConst.JPOS_E_CLOSED) {
-				deviceState = JposState.CLOSED;
-			}
-		}
-		return deviceState;
-
 	}
 }

--- a/src/main/java/postest2/GateController.java
+++ b/src/main/java/postest2/GateController.java
@@ -27,7 +27,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class GateController extends CommonController implements Initializable {
+public class GateController extends SharableController implements Initializable {
 
 	@FXML @RequiredState(JposState.ENABLED)
 	public Pane functionPane;
@@ -69,7 +69,7 @@ public class GateController extends CommonController implements Initializable {
 	public void handleOCE(ActionEvent e) {
 		super.handleOCE(e);
 		try {
-			if(getDeviceState(service) == JposState.CLAIMED){
+			if(getDeviceState(service) == JposState.OPENED){
 				deviceEnabled.setSelected(true);
 				handleDeviceEnable(e);
 			}

--- a/src/main/java/postest2/HardTotalsController.java
+++ b/src/main/java/postest2/HardTotalsController.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class HardTotalsController extends CommonController implements Initializable {
+public class HardTotalsController extends SharableController implements Initializable {
 
 	@FXML
 	@RequiredState(JposState.ENABLED)
@@ -116,7 +116,7 @@ public class HardTotalsController extends CommonController implements Initializa
 	public void handleOCE(ActionEvent e) {
 		super.handleOCE(e);
 		try {
-			if(getDeviceState(service) == JposState.CLAIMED){
+			if(getDeviceState(service) == JposState.OPENED){
 				deviceEnabled.setSelected(true);
 				handleDeviceEnable(e);
 			}

--- a/src/main/java/postest2/JposState.java
+++ b/src/main/java/postest2/JposState.java
@@ -4,5 +4,6 @@ public enum JposState {
 	CLOSED,
 	OPENED,
 	CLAIMED,
-	ENABLED;
+	ENABLED,
+	OPENEDNOTENABLED
 }

--- a/src/main/java/postest2/KeylockController.java
+++ b/src/main/java/postest2/KeylockController.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class KeylockController extends CommonController implements Initializable {
+public class KeylockController extends SharableController implements Initializable {
 
 	@FXML
 	@RequiredState(JposState.ENABLED)
@@ -73,7 +73,7 @@ public class KeylockController extends CommonController implements Initializable
 	public void handleOCE(ActionEvent e) {
 		super.handleOCE(e);
 		try {
-			if(getDeviceState(service) == JposState.CLAIMED){
+			if(getDeviceState(service) == JposState.OPENED){
 				deviceEnabled.setSelected(true);
 				handleDeviceEnable(e);
 			}

--- a/src/main/java/postest2/LineDisplayController.java
+++ b/src/main/java/postest2/LineDisplayController.java
@@ -271,6 +271,7 @@ public class LineDisplayController extends CommonController implements Initializ
 
 			} else {
 				((LineDisplay) service).setDeviceEnabled(false);
+				setUpScreenMode();
 			}
 			RequiredStateChecker.invokeThis(this, service);
 		} catch (JposException je) {

--- a/src/main/java/postest2/MotionSensorController.java
+++ b/src/main/java/postest2/MotionSensorController.java
@@ -28,7 +28,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class MotionSensorController extends CommonController implements Initializable {
+public class MotionSensorController extends SharableController implements Initializable {
 
 	@FXML
 	@RequiredState(JposState.ENABLED)
@@ -72,7 +72,7 @@ public class MotionSensorController extends CommonController implements Initiali
 	public void handleOCE(ActionEvent e) {
 		super.handleOCE(e);
 		try {
-			if(getDeviceState(service) == JposState.CLAIMED){
+			if(getDeviceState(service) == JposState.OPENED){
 				deviceEnabled.setSelected(true);
 				handleDeviceEnable(e);
 			}

--- a/src/main/java/postest2/POSPowerController.java
+++ b/src/main/java/postest2/POSPowerController.java
@@ -31,7 +31,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-public class POSPowerController extends CommonController implements Initializable, StatusUpdateListener {
+public class POSPowerController extends SharableController implements Initializable, StatusUpdateListener {
 
 	@FXML
 	@RequiredState(JposState.ENABLED)
@@ -116,7 +116,7 @@ public class POSPowerController extends CommonController implements Initializabl
 	public void handleOCE(ActionEvent e) {
 		super.handleOCE(e);
 		try {
-			if(getDeviceState(service) == JposState.CLAIMED){
+			if(getDeviceState(service) == JposState.OPENED){
 				deviceEnabled.setSelected(true);
 				handleDeviceEnable(e);
 			}

--- a/src/main/java/postest2/RequiredStateChecker.java
+++ b/src/main/java/postest2/RequiredStateChecker.java
@@ -1,6 +1,6 @@
 package postest2;
 
-import java.lang.reflect.Field;
+import java.lang.reflect.*;
 
 import javafx.scene.Node;
 import jpos.BaseJposControl;
@@ -9,7 +9,7 @@ import jpos.JposException;
 
 /**
  * This Class provides the functionality that a Field with the RequiredState-Annotation is disabled/enabled 
- * corresponding to the given Value (CLOSED, OPENED, CLAIMED, ENABLED) of the Variable
+ * corresponding to the given Value (CLOSED, OPENED, CLAIMED, ENABLED, OPENEDNOTENABLED) of the Variable
  *
  */
 public class RequiredStateChecker {
@@ -26,7 +26,7 @@ public class RequiredStateChecker {
 				//Get only those fields which are a JavaFX Node
 				if(Node.class.isAssignableFrom(fields[i].getType())){
 					Node c = (Node) fields[i].get(theObject);
-					if(requiredState != null){
+					if(requiredState != null && c != null){
 						//get the Value of each Annotation
 						JposState componentState = requiredState.value();
 						//Disable/Enable corresponding to the current deviceState and the requiredState
@@ -46,6 +46,13 @@ public class RequiredStateChecker {
 						} 
 						if(componentState == JposState.ENABLED){
 							if(deviceState == JposState.ENABLED){
+								c.setDisable(false);
+							} else {
+								c.setDisable(true);
+							}
+						}
+						if(componentState == JposState.OPENEDNOTENABLED){
+							if(deviceState == JposState.OPENED || deviceState == JposState.CLAIMED){
 								c.setDisable(false);
 							} else {
 								c.setDisable(true);

--- a/src/main/java/postest2/SharableController.java
+++ b/src/main/java/postest2/SharableController.java
@@ -1,0 +1,73 @@
+package postest2;
+
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.CheckBox;
+
+import javax.swing.JOptionPane;
+
+import jpos.JposException;
+
+public abstract class SharableController extends BaseController implements Initializable {
+
+    /* ************************************************************************
+     * *************** Action Handler For Exclusive Use Devices ***************
+     * ************************************************************************
+     */
+
+    // Common
+    @FXML
+    @RequiredState(JposState.OPENED)
+    public CheckBox deviceEnabled;
+
+    @FXML
+    public void handleRelease(ActionEvent e) {
+        try {
+            service.release();
+            if (deviceEnabled.isSelected() && service.getDeviceEnabled() == false) {
+                deviceEnabled.setSelected(false);
+            }
+
+            RequiredStateChecker.invokeThis(this, service);
+        } catch (JposException je) {
+            je.printStackTrace();
+            JOptionPane.showMessageDialog(null, "Failed to release \""
+                            + logicalName.getSelectionModel().getSelectedItem() + "\"\nException: " + je.getMessage(),
+                    "Failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    @FXML
+    public void handleClose(ActionEvent e) {
+        try {
+            service.close();
+            if (!deviceEnabled.isDisable()) {
+                deviceEnabled.setSelected(false);
+            }
+
+            if (dataEventEnabled != null && !dataEventEnabled.isDisable()) {
+                dataEventEnabled.setSelected(false);
+            }
+
+            RequiredStateChecker.invokeThis(this, service);
+            setStatusLabel();
+        } catch (JposException je) {
+            je.printStackTrace();
+            JOptionPane.showMessageDialog(null, "Failed to close \""
+                            + logicalName.getSelectionModel().getSelectedItem() + "\"\nException: " + je.getMessage(),
+                    "Failed", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    @FXML
+    public void handleOCE(ActionEvent e) {
+        try {
+            if(getDeviceState(service) == JposState.CLOSED){
+                handleOpen(e);
+            }
+        } catch (JposException e1) {
+            e1.printStackTrace();
+        }
+    }
+}

--- a/src/main/resources/postest2/gui/CashDrawer.fxml
+++ b/src/main/resources/postest2/gui/CashDrawer.fxml
@@ -20,6 +20,11 @@
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <Pane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" styleClass="whiteBackground">
               <children>
+                <Label alignment="CENTER" layoutX="108.0" layoutY="379.0" prefWidth="271.0" text="DirectIO" underline="true">
+                  <font>
+                    <Font size="14.0" />
+                  </font>
+                </Label>
                 <Label layoutX="108.0" layoutY="406.0" text="Command:" />
                 <Label layoutX="108.0" layoutY="429.0" text="Data:" />
                 <Label layoutX="108.0" layoutY="453.0" text="Object:" />
@@ -31,16 +36,24 @@
                 <RadioButton fx:id="directIO_datatypeString" layoutX="442.0" layoutY="447.0" mnemonicParsing="false" text="String" />
                 <RadioButton fx:id="directIO_datatypeByteArray" layoutX="442.0" layoutY="461.0" mnemonicParsing="false" text="Byte[]" />
                 <Button layoutX="316.0" layoutY="476.0" mnemonicParsing="false" onAction="#handleDirectIO" text="DirectIO" />
-                <Button fx:id="buttonGetDrawer" layoutX="250.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleGetDrawer" text="Get Drawer Opened" />
-                <Button fx:id="buttonWaitForDrawer" layoutX="400.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleWaitForDrawer" text="Wait For Drawer Close" />
-                <Button fx:id="buttonOpenCash" layoutX="108.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleOpenCash" text="Open Cash Drawer" />
-                <Text layoutX="284.0" layoutY="128.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Action Log" />
-                <TextArea fx:id="textAreaActionLog" layoutX="108.0" layoutY="131.0" prefHeight="214.0" prefWidth="430.0" wrapText="true" />
-                <Label alignment="CENTER" layoutX="108.0" layoutY="379.0" prefWidth="270.912109375" text="DirectIO" underline="true">
+                <Label alignment="CENTER" layoutX="538.0" layoutY="379.0" prefWidth="271.0" text="Wait For Drawer Close" underline="true">
                   <font>
                     <Font size="14.0" />
                   </font>
                 </Label>
+                <Label layoutX="538.0" layoutY="406.0" text="beepTimeout:" />
+                <Label layoutX="538.0" layoutY="429.0" text="beepFrequency:" />
+                <Label layoutX="538.0" layoutY="452.0" text="beepDuration:" />
+                <Label layoutX="538.0" layoutY="475.0" text="beepDelay:" />
+                <TextField fx:id="waitForDrawerClose_beepTimeout"   layoutX="631.0" layoutY="403.0" prefWidth="80.0" />
+                <TextField fx:id="waitForDrawerClose_beepFrequency" layoutX="631.0" layoutY="426.0" prefWidth="80.0" />
+                <TextField fx:id="waitForDrawerClose_beepDuration"  layoutX="631.0" layoutY="449.0" prefWidth="80.0" />
+                <TextField fx:id="waitForDrawerClose_beepDelay"     layoutX="631.0" layoutY="471.0" prefWidth="80.0" />
+                <Button fx:id="buttonWaitForDrawer" layoutX="720.0" layoutY="401.0" mnemonicParsing="false" onAction="#handleWaitForDrawer" text="Wait For Drawer Close" />
+                <Button fx:id="buttonGetDrawer" layoutX="250.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleGetDrawer" text="Get Drawer Opened" />
+                <Button fx:id="buttonOpenCash" layoutX="108.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleOpenCash" text="Open Cash Drawer" />
+                <Text layoutX="284.0" layoutY="128.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Action Log" />
+                <TextArea fx:id="textAreaActionLog" layoutX="108.0" layoutY="131.0" prefHeight="214.0" prefWidth="430.0" wrapText="true" />
               </children>
             </Pane>
           </children>
@@ -61,7 +74,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/src/main/resources/postest2/gui/CoinDispenser.fxml
+++ b/src/main/resources/postest2/gui/CoinDispenser.fxml
@@ -47,15 +47,10 @@
                 <Label layoutX="557.0" layoutY="109.0" text="Discrepancy:" />
                 <Label fx:id="readCashCount_cashCount" layoutX="643.0" layoutY="84.0" prefWidth="91.0" />
                 <Label fx:id="readCashCount_discrepancy" layoutX="643.0" layoutY="109.0" prefWidth="91.0" />
-                <TextField id="adjustCashCounts" layoutX="390.0" layoutY="80.0" prefWidth="122.0" />
+                <TextField fx:id="dispenseCash_cashCounts" layoutX="390.0" layoutY="80.0" prefWidth="122.0" />
                 <Label alignment="CENTER" font="$x1" layoutX="35.0" layoutY="165.0" prefWidth="272.0" text="DirectIO" underline="true" />
               </children>
             </Pane>
-            <Text fill="RED" layoutX="50.0" layoutY="680.0" scaleX="1.078" strokeType="OUTSIDE" strokeWidth="0.0" text="Not tested with a Device! If any Errors occur, please contact us on our Sourceforge Projectsite.">
-              <font>
-                <Font size="16.0" />
-              </font>
-            </Text>
           </children>
         </Pane>
       </center>

--- a/src/main/resources/postest2/gui/ElectronicJournal.fxml
+++ b/src/main/resources/postest2/gui/ElectronicJournal.fxml
@@ -19,6 +19,7 @@
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <CheckBox fx:id="asyncMode" layoutX="14.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleAsyncMode" text="Asynchronous Mode" />
             <CheckBox fx:id="flagWhenIdle" layoutX="155.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleFlagWhenIdle" text="Flag when idle" />
+            <CheckBox fx:id="dataEventEnabled" layoutX="295.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleDataEventEnabled" text="Data event enabled" />
             <TabPane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE">
               <stylesheets>
                 <URL value="@win7glass.css" />
@@ -155,11 +156,6 @@
                 </Tab>
               </tabs>
             </TabPane>
-            <Text fill="RED" layoutX="50.0" layoutY="680.0" scaleX="1.078" strokeType="OUTSIDE" strokeWidth="0.0" text="Not tested with a Device! If any Errors occur, please contact us on our Sourceforge Projectsite.">
-              <font>
-                <Font size="16.0" />
-              </font>
-            </Text>
           </children>
         </Pane>
       </center>
@@ -167,7 +163,7 @@
         <Pane prefHeight="92.0" styleClass="topPane">
           <children>
             <Text fontSmoothingType="LCD" layoutX="14.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Logical name: " />
-            <ComboBox layoutX="101.0" layoutY="9.0" prefHeight="21.0" prefWidth="113.0" />
+            <ComboBox fx:id="logicalName" layoutX="101.0" layoutY="9.0" prefHeight="21.0" prefWidth="113.0" />
             <Text fontSmoothingType="LCD" layoutX="277.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="State: " />
             <Text fx:id="statusLabel" fontSmoothingType="LCD" layoutX="320.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="JPOS_S_CLOSED">
               <font>

--- a/src/main/resources/postest2/gui/Gate.fxml
+++ b/src/main/resources/postest2/gui/Gate.fxml
@@ -66,7 +66,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/src/main/resources/postest2/gui/HardTotals.fxml
+++ b/src/main/resources/postest2/gui/HardTotals.fxml
@@ -161,7 +161,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/src/main/resources/postest2/gui/Keylock.fxml
+++ b/src/main/resources/postest2/gui/Keylock.fxml
@@ -66,7 +66,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/src/main/resources/postest2/gui/LineDisplay.fxml
+++ b/src/main/resources/postest2/gui/LineDisplay.fxml
@@ -4,7 +4,6 @@
 <?import javafx.collections.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.text.*?>
 <?scenebuilder-stylesheet win7glass.css?>
 
@@ -16,7 +15,7 @@
           <children>
             <CheckBox fx:id="deviceEnabled" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleDeviceEnable" text="Device enabled" />
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
-            <TabPane fx:id="functionTab" layoutX="33.0" layoutY="71.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${!deviceEnabled.selected}">
+            <TabPane fx:id="functionTab" layoutX="33.0" layoutY="71.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${deviceEnabled.selected}">
               <tabs>
                 <Tab text="Display Text">
                   <content>
@@ -197,7 +196,7 @@
                 </Tab>
               </tabs>
             </TabPane>
-            <TabPane fx:id="notEnabledTab" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${deviceEnabled.selected}">
+            <TabPane fx:id="notEnabledTab" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${!deviceEnabled.selected}">
               <tabs>
                 <Tab text="Screen Mode">
                   <content>

--- a/src/main/resources/postest2/gui/MainWindow.fxml
+++ b/src/main/resources/postest2/gui/MainWindow.fxml
@@ -6,7 +6,6 @@
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.paint.*?>
 <?import javafx.scene.text.*?>
 <?scenebuilder-stylesheet win7glass.css?>

--- a/src/main/resources/postest2/gui/MotionSensor.fxml
+++ b/src/main/resources/postest2/gui/MotionSensor.fxml
@@ -67,7 +67,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/src/main/resources/postest2/gui/POSPower.fxml
+++ b/src/main/resources/postest2/gui/POSPower.fxml
@@ -71,7 +71,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/src/main/resources/postest2/gui/RemoteOrderDisplay.fxml
+++ b/src/main/resources/postest2/gui/RemoteOrderDisplay.fxml
@@ -18,6 +18,7 @@
             <CheckBox fx:id="deviceEnabled" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleDeviceEnable" text="Device enabled" />
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <CheckBox fx:id="asyncMode" layoutX="14.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleAsyncMode" text="Asynchronous Mode" />
+            <CheckBox fx:id="dataEventEnabled" layoutX="155.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleDataEventEnabled" text="DataEvent enabled" />
             <TabPane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE">
               <stylesheets>
                 <URL value="@win7glass.css" />
@@ -291,6 +292,11 @@
             <ComboBox fx:id="logicalName" layoutX="101.0" layoutY="9.0" prefHeight="21.0" prefWidth="113.0" />
             <Text fontSmoothingType="LCD" layoutX="277.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="State: " />
             <Text fx:id="statusLabel" fontSmoothingType="LCD" layoutX="320.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="JPOS_S_CLOSED">
+              <font>
+                <Font name="System Bold" size="12.0" />
+              </font>
+            </Text>
+            <Text fx:id="inputLabel" fontSmoothingType="LCD" layoutX="635.0" layoutY="71.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Input:                                     ">
               <font>
                 <Font name="System Bold" size="12.0" />
               </font>

--- a/src/main/resources/postest2/gui/Scale.fxml
+++ b/src/main/resources/postest2/gui/Scale.fxml
@@ -18,6 +18,14 @@
             <CheckBox fx:id="deviceEnabled" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleDeviceEnable" text="Device enabled" />
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <CheckBox fx:id="asyncMode" layoutX="14.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleAsyncMode" text="Asynchronous Mode" />
+            <CheckBox fx:id="dataEventEnabled" layoutX="155.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleDataEventEnabled" text="DataEvent enabled" />
+            <Pane fx:id="statusNotifyPane" layoutX="500.0" layoutY="0.0" prefHeight="50.0" prefWidth="310.0">
+              <children>
+                <ComboBox fx:id="statusNotify" layoutX="120.0" layoutY="10.0" prefHeight="21.0" prefWidth="113.0" />
+                <Label layoutX="15.0" layoutY="13.0" text="Set StatusNotify:" />
+                <Button layoutX="242.0" layoutY="8.0" mnemonicParsing="false" onAction="#handleSetStatusNotify" prefWidth="105.0" text="SetStatusNotify" />
+              </children>
+            </Pane>
             <Pane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" styleClass="whiteBackground">
               <children>
                 <Label layoutX="358.0" layoutY="376.0" text="Command:" />
@@ -31,9 +39,6 @@
                 <RadioButton fx:id="directIO_datatypeString" layoutX="692.0" layoutY="417.0" mnemonicParsing="false" text="String" />
                 <RadioButton fx:id="directIO_datatypeByteArray" layoutX="692.0" layoutY="430.0" mnemonicParsing="false" text="Byte[]" />
                 <Button layoutX="566.0" layoutY="446.0" mnemonicParsing="false" onAction="#handleDirectIO" text="DirectIO" />
-                <ComboBox fx:id="statusNotify" layoutX="130.0" layoutY="45.0" prefHeight="21.0" prefWidth="113.0" />
-                <Label layoutX="25.0" layoutY="48.0" text="Set StatusNotify:" />
-                <Button layoutX="252.0" layoutY="43.0" mnemonicParsing="false" onAction="#handleSetStatusNotify" prefWidth="105.0" text="SetStatusNotify" />
                 <Label layoutX="25.0" layoutY="83.0" text="Set TareWeight:" />
                 <Button layoutX="252.0" layoutY="78.0" mnemonicParsing="false" onAction="#handleSetTareWeight" prefWidth="105.0" text="SetTareWeight" />
                 <Label layoutX="25.0" layoutY="120.0" text="Set UnitPrice:" />
@@ -62,11 +67,6 @@
                 <Label alignment="CENTER" font="$x1" layoutX="358.0" layoutY="347.0" prefWidth="271.999977929685" text="DirectIO" underline="true" />
               </children>
             </Pane>
-            <Text fill="RED" layoutX="50.0" layoutY="680.0" scaleX="1.078" strokeType="OUTSIDE" strokeWidth="0.0" text="Not tested with a Device! If any Errors occur, please contact us on our Sourceforge Projectsite.">
-              <font>
-                <Font size="16.0" />
-              </font>
-            </Text>
           </children>
         </Pane>
       </center>

--- a/src/main/resources/postest2/gui/ToneIndicator.fxml
+++ b/src/main/resources/postest2/gui/ToneIndicator.fxml
@@ -104,7 +104,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/src/main/resources/postest2/gui/win7glass.css
+++ b/src/main/resources/postest2/gui/win7glass.css
@@ -20,6 +20,7 @@ menu item is being hovered.
 .root {
     -fx-text-base-color: #000000;
     -fx-background-color: #BCC6CC;
+    -fx-disabled-opacity: 0.3
 }
 
 .pane {

--- a/target/classes/posTest2/gui/CashDrawer.fxml
+++ b/target/classes/posTest2/gui/CashDrawer.fxml
@@ -20,6 +20,11 @@
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <Pane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" styleClass="whiteBackground">
               <children>
+                <Label alignment="CENTER" layoutX="108.0" layoutY="379.0" prefWidth="271.0" text="DirectIO" underline="true">
+                  <font>
+                    <Font size="14.0" />
+                  </font>
+                </Label>
                 <Label layoutX="108.0" layoutY="406.0" text="Command:" />
                 <Label layoutX="108.0" layoutY="429.0" text="Data:" />
                 <Label layoutX="108.0" layoutY="453.0" text="Object:" />
@@ -31,16 +36,24 @@
                 <RadioButton fx:id="directIO_datatypeString" layoutX="442.0" layoutY="447.0" mnemonicParsing="false" text="String" />
                 <RadioButton fx:id="directIO_datatypeByteArray" layoutX="442.0" layoutY="461.0" mnemonicParsing="false" text="Byte[]" />
                 <Button layoutX="316.0" layoutY="476.0" mnemonicParsing="false" onAction="#handleDirectIO" text="DirectIO" />
-                <Button fx:id="buttonGetDrawer" layoutX="250.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleGetDrawer" text="Get Drawer Opened" />
-                <Button fx:id="buttonWaitForDrawer" layoutX="400.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleWaitForDrawer" text="Wait For Drawer Close" />
-                <Button fx:id="buttonOpenCash" layoutX="108.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleOpenCash" text="Open Cash Drawer" />
-                <Text layoutX="284.0" layoutY="128.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Action Log" />
-                <TextArea fx:id="textAreaActionLog" layoutX="108.0" layoutY="131.0" prefHeight="214.0" prefWidth="430.0" wrapText="true" />
-                <Label alignment="CENTER" layoutX="108.0" layoutY="379.0" prefWidth="270.912109375" text="DirectIO" underline="true">
+                <Label alignment="CENTER" layoutX="538.0" layoutY="379.0" prefWidth="271.0" text="Wait For Drawer Close" underline="true">
                   <font>
                     <Font size="14.0" />
                   </font>
                 </Label>
+                <Label layoutX="538.0" layoutY="406.0" text="beepTimeout:" />
+                <Label layoutX="538.0" layoutY="429.0" text="beepFrequency:" />
+                <Label layoutX="538.0" layoutY="452.0" text="beepDuration:" />
+                <Label layoutX="538.0" layoutY="475.0" text="beepDelay:" />
+                <TextField fx:id="waitForDrawerClose_beepTimeout"   layoutX="631.0" layoutY="403.0" prefWidth="80.0" />
+                <TextField fx:id="waitForDrawerClose_beepFrequency" layoutX="631.0" layoutY="426.0" prefWidth="80.0" />
+                <TextField fx:id="waitForDrawerClose_beepDuration"  layoutX="631.0" layoutY="449.0" prefWidth="80.0" />
+                <TextField fx:id="waitForDrawerClose_beepDelay"     layoutX="631.0" layoutY="471.0" prefWidth="80.0" />
+                <Button fx:id="buttonWaitForDrawer" layoutX="720.0" layoutY="401.0" mnemonicParsing="false" onAction="#handleWaitForDrawer" text="Wait For Drawer Close" />
+                <Button fx:id="buttonGetDrawer" layoutX="250.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleGetDrawer" text="Get Drawer Opened" />
+                <Button fx:id="buttonOpenCash" layoutX="108.0" layoutY="49.0" mnemonicParsing="false" onAction="#handleOpenCash" text="Open Cash Drawer" />
+                <Text layoutX="284.0" layoutY="128.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Action Log" />
+                <TextArea fx:id="textAreaActionLog" layoutX="108.0" layoutY="131.0" prefHeight="214.0" prefWidth="430.0" wrapText="true" />
               </children>
             </Pane>
           </children>
@@ -61,7 +74,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/target/classes/posTest2/gui/CoinDispenser.fxml
+++ b/target/classes/posTest2/gui/CoinDispenser.fxml
@@ -47,15 +47,10 @@
                 <Label layoutX="557.0" layoutY="109.0" text="Discrepancy:" />
                 <Label fx:id="readCashCount_cashCount" layoutX="643.0" layoutY="84.0" prefWidth="91.0" />
                 <Label fx:id="readCashCount_discrepancy" layoutX="643.0" layoutY="109.0" prefWidth="91.0" />
-                <TextField id="adjustCashCounts" layoutX="390.0" layoutY="80.0" prefWidth="122.0" />
+                <TextField fx:id="dispenseCash_cashCounts" layoutX="390.0" layoutY="80.0" prefWidth="122.0" />
                 <Label alignment="CENTER" font="$x1" layoutX="35.0" layoutY="165.0" prefWidth="272.0" text="DirectIO" underline="true" />
               </children>
             </Pane>
-            <Text fill="RED" layoutX="50.0" layoutY="680.0" scaleX="1.078" strokeType="OUTSIDE" strokeWidth="0.0" text="Not tested with a Device! If any Errors occur, please contact us on our Sourceforge Projectsite.">
-              <font>
-                <Font size="16.0" />
-              </font>
-            </Text>
           </children>
         </Pane>
       </center>

--- a/target/classes/posTest2/gui/ElectronicJournal.fxml
+++ b/target/classes/posTest2/gui/ElectronicJournal.fxml
@@ -19,6 +19,7 @@
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <CheckBox fx:id="asyncMode" layoutX="14.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleAsyncMode" text="Asynchronous Mode" />
             <CheckBox fx:id="flagWhenIdle" layoutX="155.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleFlagWhenIdle" text="Flag when idle" />
+            <CheckBox fx:id="dataEventEnabled" layoutX="295.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleDataEventEnabled" text="Data event enabled" />
             <TabPane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE">
               <stylesheets>
                 <URL value="@win7glass.css" />
@@ -155,11 +156,6 @@
                 </Tab>
               </tabs>
             </TabPane>
-            <Text fill="RED" layoutX="50.0" layoutY="680.0" scaleX="1.078" strokeType="OUTSIDE" strokeWidth="0.0" text="Not tested with a Device! If any Errors occur, please contact us on our Sourceforge Projectsite.">
-              <font>
-                <Font size="16.0" />
-              </font>
-            </Text>
           </children>
         </Pane>
       </center>
@@ -167,7 +163,7 @@
         <Pane prefHeight="92.0" styleClass="topPane">
           <children>
             <Text fontSmoothingType="LCD" layoutX="14.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Logical name: " />
-            <ComboBox layoutX="101.0" layoutY="9.0" prefHeight="21.0" prefWidth="113.0" />
+            <ComboBox fx:id="logicalName" layoutX="101.0" layoutY="9.0" prefHeight="21.0" prefWidth="113.0" />
             <Text fontSmoothingType="LCD" layoutX="277.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="State: " />
             <Text fx:id="statusLabel" fontSmoothingType="LCD" layoutX="320.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="JPOS_S_CLOSED">
               <font>

--- a/target/classes/posTest2/gui/Gate.fxml
+++ b/target/classes/posTest2/gui/Gate.fxml
@@ -66,7 +66,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/target/classes/posTest2/gui/HardTotals.fxml
+++ b/target/classes/posTest2/gui/HardTotals.fxml
@@ -161,7 +161,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/target/classes/posTest2/gui/Keylock.fxml
+++ b/target/classes/posTest2/gui/Keylock.fxml
@@ -66,7 +66,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/target/classes/posTest2/gui/MotionSensor.fxml
+++ b/target/classes/posTest2/gui/MotionSensor.fxml
@@ -67,7 +67,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/target/classes/posTest2/gui/POSPower.fxml
+++ b/target/classes/posTest2/gui/POSPower.fxml
@@ -71,7 +71,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/target/classes/posTest2/gui/RemoteOrderDisplay.fxml
+++ b/target/classes/posTest2/gui/RemoteOrderDisplay.fxml
@@ -18,6 +18,7 @@
             <CheckBox fx:id="deviceEnabled" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleDeviceEnable" text="Device enabled" />
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <CheckBox fx:id="asyncMode" layoutX="14.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleAsyncMode" text="Asynchronous Mode" />
+            <CheckBox fx:id="dataEventEnabled" layoutX="155.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleDataEventEnabled" text="DataEvent enabled" />
             <TabPane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE">
               <stylesheets>
                 <URL value="@win7glass.css" />
@@ -291,6 +292,11 @@
             <ComboBox fx:id="logicalName" layoutX="101.0" layoutY="9.0" prefHeight="21.0" prefWidth="113.0" />
             <Text fontSmoothingType="LCD" layoutX="277.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="State: " />
             <Text fx:id="statusLabel" fontSmoothingType="LCD" layoutX="320.0" layoutY="27.0" strokeType="OUTSIDE" strokeWidth="0.0" text="JPOS_S_CLOSED">
+              <font>
+                <Font name="System Bold" size="12.0" />
+              </font>
+            </Text>
+            <Text fx:id="inputLabel" fontSmoothingType="LCD" layoutX="635.0" layoutY="71.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Input:                                     ">
               <font>
                 <Font name="System Bold" size="12.0" />
               </font>

--- a/target/classes/posTest2/gui/Scale.fxml
+++ b/target/classes/posTest2/gui/Scale.fxml
@@ -18,6 +18,14 @@
             <CheckBox fx:id="deviceEnabled" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleDeviceEnable" text="Device enabled" />
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
             <CheckBox fx:id="asyncMode" layoutX="14.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleAsyncMode" text="Asynchronous Mode" />
+            <CheckBox fx:id="dataEventEnabled" layoutX="155.0" layoutY="40.0" mnemonicParsing="false" onAction="#handleDataEventEnabled" text="DataEvent enabled" />
+            <Pane fx:id="statusNotifyPane" layoutX="500.0" layoutY="0.0" prefHeight="50.0" prefWidth="310.0">
+              <children>
+                <ComboBox fx:id="statusNotify" layoutX="120.0" layoutY="10.0" prefHeight="21.0" prefWidth="113.0" />
+                <Label layoutX="15.0" layoutY="13.0" text="Set StatusNotify:" />
+                <Button layoutX="242.0" layoutY="8.0" mnemonicParsing="false" onAction="#handleSetStatusNotify" prefWidth="105.0" text="SetStatusNotify" />
+              </children>
+            </Pane>
             <Pane fx:id="functionPane" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" styleClass="whiteBackground">
               <children>
                 <Label layoutX="358.0" layoutY="376.0" text="Command:" />
@@ -31,9 +39,6 @@
                 <RadioButton fx:id="directIO_datatypeString" layoutX="692.0" layoutY="417.0" mnemonicParsing="false" text="String" />
                 <RadioButton fx:id="directIO_datatypeByteArray" layoutX="692.0" layoutY="430.0" mnemonicParsing="false" text="Byte[]" />
                 <Button layoutX="566.0" layoutY="446.0" mnemonicParsing="false" onAction="#handleDirectIO" text="DirectIO" />
-                <ComboBox fx:id="statusNotify" layoutX="130.0" layoutY="45.0" prefHeight="21.0" prefWidth="113.0" />
-                <Label layoutX="25.0" layoutY="48.0" text="Set StatusNotify:" />
-                <Button layoutX="252.0" layoutY="43.0" mnemonicParsing="false" onAction="#handleSetStatusNotify" prefWidth="105.0" text="SetStatusNotify" />
                 <Label layoutX="25.0" layoutY="83.0" text="Set TareWeight:" />
                 <Button layoutX="252.0" layoutY="78.0" mnemonicParsing="false" onAction="#handleSetTareWeight" prefWidth="105.0" text="SetTareWeight" />
                 <Label layoutX="25.0" layoutY="120.0" text="Set UnitPrice:" />
@@ -62,11 +67,6 @@
                 <Label alignment="CENTER" font="$x1" layoutX="358.0" layoutY="347.0" prefWidth="271.999977929685" text="DirectIO" underline="true" />
               </children>
             </Pane>
-            <Text fill="RED" layoutX="50.0" layoutY="680.0" scaleX="1.078" strokeType="OUTSIDE" strokeWidth="0.0" text="Not tested with a Device! If any Errors occur, please contact us on our Sourceforge Projectsite.">
-              <font>
-                <Font size="16.0" />
-              </font>
-            </Text>
           </children>
         </Pane>
       </center>

--- a/target/classes/posTest2/gui/ToneIndicator.fxml
+++ b/target/classes/posTest2/gui/ToneIndicator.fxml
@@ -104,7 +104,7 @@
             <Button fx:id="buttonClaim" layoutX="83.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClaim" prefWidth="61.0" text="Claim" />
             <Button fx:id="buttonRelease" layoutX="152.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleRelease" prefWidth="61.0" text="Release" />
             <Button fx:id="buttonClose" layoutX="221.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleClose" prefWidth="61.0" text="Close" />
-            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/C/E" />
+            <Button fx:id="buttonOCE" layoutX="320.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleOCE" text="O/E" />
             <Button fx:id="buttonInfo" layoutX="410.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleInfo" text="Info" />
             <Button fx:id="buttonFirmware" layoutX="461.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleFirmware" text="Firmware" />
             <Button fx:id="buttonStatistics" layoutX="539.0" layoutY="53.0" mnemonicParsing="false" onAction="#handleStatistics" text="Statistics" />

--- a/target/classes/postest2/gui/LineDisplay.fxml
+++ b/target/classes/postest2/gui/LineDisplay.fxml
@@ -4,7 +4,6 @@
 <?import javafx.collections.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.text.*?>
 <?scenebuilder-stylesheet win7glass.css?>
 
@@ -16,7 +15,7 @@
           <children>
             <CheckBox fx:id="deviceEnabled" layoutX="14.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleDeviceEnable" text="Device enabled" />
             <CheckBox fx:id="freezeEvents" layoutX="155.0" layoutY="14.0" mnemonicParsing="false" onAction="#handleFreezeEvents" text="Freeze events" />
-            <TabPane fx:id="functionTab" layoutX="33.0" layoutY="71.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${!deviceEnabled.selected}">
+            <TabPane fx:id="functionTab" layoutX="33.0" layoutY="71.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${deviceEnabled.selected}">
               <tabs>
                 <Tab text="Display Text">
                   <content>
@@ -197,7 +196,7 @@
                 </Tab>
               </tabs>
             </TabPane>
-            <TabPane fx:id="notEnabledTab" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${deviceEnabled.selected}">
+            <TabPane fx:id="notEnabledTab" layoutX="14.0" layoutY="70.0" prefHeight="590.0" prefWidth="910.0" tabClosingPolicy="UNAVAILABLE" visible="${!deviceEnabled.selected}">
               <tabs>
                 <Tab text="Screen Mode">
                   <content>


### PR DESCRIPTION
Several fixes:
- Sharable devices do not require claim.
- Sharable devices do not disable device during release.
- CashDrawer waitForDrawerClose requires parameters beepTimeout, beepFrequency, beepDuration and beepDelay. Standard values are not enough for testing.
- CAT: Status label updates after invokation and after output complete event in async mode. PaymentMedia and AdditionalSecurityInformation update after method completed.
- CoinDispenser: handleDispenseCash call correct method with correct parameter now, "Not tessted..." label removed..
- ElectronicJournal: Added status update for async processing, use correct marketType in retrieveMarker and retrieveMarkerByDateTime, from and to marker may be empty in query and print method, Checkbox dataEventEnabled added, "Not tessted..." label removed, missing fx:id for logicalName added.
- LineDisplay: setUpScreenMode added in deviceEnabled, visibility od TabPanes fixed.
- RemoreOrderDisplay: New label to show input data, event handling added, partly automatic DataEventEnable added, use width and height instead of two times height in saveVideoRegion.
- RequiredStateChecker checks for new value OPENEDNOTENABLED to allow correct settings for GUI objects that are only allowed between open and enable.
- Scale: StatusNotify only allowed between open and enable, initialization to defaults, data and error listener for asynchronous processing, update tareWeight and unitPrice after readWeight completes, dataEventEnabled checkbox added.